### PR TITLE
Fixed wrong argument being used in the makeButton method in sample-fe…

### DIFF
--- a/sample-fetch-image/src/App.js
+++ b/sample-fetch-image/src/App.js
@@ -8,7 +8,7 @@ export default async function start (app) {
   prism.getRootNode().addChild(text);
   text.setLocalPosition([0, 0.2, 0]);
   // Add button
-  let button = makeButton(this, prism, text);
+  let button = makeButton(app, prism, text);
   button.setLocalPosition([0, -0.2, 0]);
   prism.getRootNode().addChild(button);
   return prism;


### PR DESCRIPTION
…tch-image.

The usage of "this" instead of "app" caused the following error message to be displayed in the application:

- "basicFetch - Error: Cannot read property 'getWritablePath' of undefined"

After changing the argument, the placeholder image appears successfully with the message

- "basicFetch - Success:"